### PR TITLE
#2 결제 데이터 CRUD JPA

### DIFF
--- a/src/main/java/com/pay/billing/BillingApplication.java
+++ b/src/main/java/com/pay/billing/BillingApplication.java
@@ -1,12 +1,20 @@
 package com.pay.billing;
 
+import com.pay.billing.domain.dto.RoleDTO;
+import com.pay.billing.domain.model.User;
+import com.pay.billing.service.UserService;
 import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 @SpringBootApplication
-public class BillingApplication {
+public class BillingApplication implements CommandLineRunner {
 
     public static void main(String[] args) {
         SpringApplication.run(BillingApplication.class, args);
@@ -15,5 +23,19 @@ public class BillingApplication {
     @Bean
     public ModelMapper modelMapper() {
         return new ModelMapper();
+    }
+
+    @Autowired
+    UserService userService;
+
+    @Override
+    public void run(String... params) throws Exception {
+        User admin = new User();
+        admin.setUsername("admin");
+        admin.setPassword("admin");
+        admin.setEmail("admin@email.com");
+        admin.setRoleDTOS(new ArrayList<RoleDTO>(Arrays.asList(RoleDTO.ROLE_ADMIN)));
+
+        userService.signup(admin);
     }
 }

--- a/src/main/java/com/pay/billing/common/config/SwaggerConfig.java
+++ b/src/main/java/com/pay/billing/common/config/SwaggerConfig.java
@@ -41,7 +41,8 @@ public class SwaggerConfig {
 
     private ApiInfo swaggerInfo() {
         return new ApiInfoBuilder().title("빌링 시스템 개발")
-                .description("카드결제 / 결제취소 / 결제정보 조회 REST API 개발 문서입니다").build();
+                .description("유저인증 / 카드결제 / 결제취소 / 결제정보 \n" +
+                        "REST API 개발 문서입니다").build();
     }
 
     // 보안 체계(Authorization)를 jwt를 header에 삽입하여 사용

--- a/src/main/java/com/pay/billing/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/pay/billing/common/config/WebSecurityConfig.java
@@ -43,16 +43,17 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/users/signup").permitAll()
                 .antMatchers("/h2-console/**/**").permitAll()
                 // 다른것들은 모두 비활성화
-                .anyRequest().authenticated();
+                .anyRequest().authenticated()
+                .and()
+                .formLogin()
+                .defaultSuccessUrl("/swagger-ui.html");
 
-        // 요구사항을 만족하지 않는다면 예외(exceptionHandling)를 발생 시킨다.
-        http.exceptionHandling().accessDeniedPage("/login");
+        // 인증 오류 처리시 accessDenied.jsp 페이지 지정
+        http.exceptionHandling().accessDeniedPage("/login?error");
 
         // Security에 JWT 적용
         http.apply(new JwtTokenFilterConfigurer(jwtTokenProvider));
 
-        // Optional, if you want to test the API from a browser
-        // http.httpBasic();
     }
 
     @Override

--- a/src/main/java/com/pay/billing/common/exception/pay/GetPaymentException.java
+++ b/src/main/java/com/pay/billing/common/exception/pay/GetPaymentException.java
@@ -1,0 +1,13 @@
+package com.pay.billing.common.exception.pay;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class GetPaymentException extends RuntimeException {
+
+    public GetPaymentException(String msg) {
+        super(msg);
+    }
+
+}

--- a/src/main/java/com/pay/billing/common/exception/pay/PostPaymentException.java
+++ b/src/main/java/com/pay/billing/common/exception/pay/PostPaymentException.java
@@ -1,0 +1,13 @@
+package com.pay.billing.common.exception.pay;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class PostPaymentException extends RuntimeException {
+
+    public PostPaymentException(String msg) {
+        super(msg);
+    }
+
+}

--- a/src/main/java/com/pay/billing/common/exception/pay/PutPaymentException.java
+++ b/src/main/java/com/pay/billing/common/exception/pay/PutPaymentException.java
@@ -1,0 +1,13 @@
+package com.pay.billing.common.exception.pay;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class PutPaymentException extends RuntimeException {
+
+    public PutPaymentException(String msg) {
+        super(msg);
+    }
+
+}

--- a/src/main/java/com/pay/billing/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/pay/billing/common/security/JwtTokenProvider.java
@@ -1,7 +1,7 @@
 package com.pay.billing.common.security;
 
 import com.pay.billing.common.exception.token.validateTokenException;
-import com.pay.billing.domain.model.Role;
+import com.pay.billing.domain.dto.RoleDTO;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -44,10 +44,10 @@ public class JwtTokenProvider {
         secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
     }
 
-    public String createToken(String username, List<Role> roles) {
+    public String createToken(String username, List<RoleDTO> roleDTOS) {
 
         Claims claims = Jwts.claims().setSubject(username);
-        claims.put("auth", roles.stream().map(s -> new SimpleGrantedAuthority(s.getAuthority())).filter(Objects::nonNull).collect(Collectors.toList()));
+        claims.put("auth", roleDTOS.stream().map(s -> new SimpleGrantedAuthority(s.getAuthority())).filter(Objects::nonNull).collect(Collectors.toList()));
 
         Date now = new Date();
         Date validity = new Date(now.getTime() + validityInMilliseconds);

--- a/src/main/java/com/pay/billing/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/pay/billing/common/security/JwtTokenProvider.java
@@ -15,9 +15,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
-import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -38,11 +36,6 @@ public class JwtTokenProvider {
 
     @Autowired
     private MyUserDetails myUserDetails;
-
-    @PostConstruct
-    protected void init() {
-        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
-    }
 
     public String createToken(String username, List<RoleDTO> roleDTOS) {
 

--- a/src/main/java/com/pay/billing/common/security/MyUserDetails.java
+++ b/src/main/java/com/pay/billing/common/security/MyUserDetails.java
@@ -30,7 +30,7 @@ public class MyUserDetails implements UserDetailsService {
         return org.springframework.security.core.userdetails.User
                 .withUsername(username)
                 .password(user.getPassword())
-                .authorities(user.getRoles())
+                .authorities(user.getRoleDTOS())
                 .accountExpired(false)
                 .accountLocked(false)
                 .credentialsExpired(false)

--- a/src/main/java/com/pay/billing/controller/PaymentController.java
+++ b/src/main/java/com/pay/billing/controller/PaymentController.java
@@ -1,0 +1,69 @@
+package com.pay.billing.controller;
+
+import com.pay.billing.common.exception.pay.GetPaymentException;
+import com.pay.billing.common.exception.pay.PostPaymentException;
+import com.pay.billing.common.exception.pay.PutPaymentException;
+import com.pay.billing.domain.dto.PaymentDTO;
+import com.pay.billing.service.PaymentService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@AllArgsConstructor
+@RequestMapping(value = "/payment")
+@RestController
+public class PaymentController {
+
+    private PaymentService paymentService;
+
+    // 결제 진행
+    @PostMapping
+    @ResponseStatus(HttpStatus.OK)
+    public Map<String, Object> postPayment(@RequestBody PaymentDTO paymentDTO) {
+        if (paymentDTO.getCrdtCardNum() == null || paymentDTO.getCvc() == null
+                || paymentDTO.getInstallment() == null || paymentDTO.getPayAmount() == null || paymentDTO.getValidYm() == null) {
+            throw new PostPaymentException("postPayment Parameter Error");
+        }
+
+        Map<String, Object> result = new HashMap<String, Object>();
+
+        try {
+            result = paymentService.postPaymentData(paymentDTO);
+        } catch (Exception e) {
+
+        }
+
+        return result;
+
+    }
+
+    // 결제 내역 조회
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public Map<String, Object> getPayment(@RequestBody PaymentDTO paymentDTO) {
+        if (paymentDTO.getId() == null) {
+            throw new GetPaymentException("getPayment Parameter Error");
+        }
+
+        return paymentService.getPaymentData(paymentDTO);
+    }
+
+    // 결제 취소 (전체/부분)
+    @PutMapping
+    @ResponseStatus(HttpStatus.OK)
+    public Map<String, Object> putPayment(@RequestBody PaymentDTO paymentDTO) {
+        if (paymentDTO.getCancelAmount() == null) {
+            throw new PutPaymentException("putPayment Parameter Error");
+        }
+
+        if (paymentDTO.getCancelVat() != null && paymentDTO.getCancelVat() > paymentDTO.getCancelAmount()) {
+            throw new PutPaymentException("Vat is bigger than Amout");
+        }
+
+        return paymentService.putPaymentData(paymentDTO);
+
+    }
+}

--- a/src/main/java/com/pay/billing/domain/dto/PaymentDTO.java
+++ b/src/main/java/com/pay/billing/domain/dto/PaymentDTO.java
@@ -1,0 +1,36 @@
+package com.pay.billing.domain.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class PaymentDTO {
+	
+	private Long id;
+	
+	private String crdtCardNum;
+	
+	private String validYm;
+	
+	private String cvc;
+	
+	private String encryptedCardInfo;
+	
+	private Long installment;
+	
+	private Long payAmount;
+	
+	private Long cancelAmount;
+	
+	private Long payVat;
+	
+	private Long cancelVat;
+	
+	private String apprYn;
+	
+	private String instDtm;
+	 
+}

--- a/src/main/java/com/pay/billing/domain/dto/RoleDTO.java
+++ b/src/main/java/com/pay/billing/domain/dto/RoleDTO.java
@@ -1,9 +1,9 @@
-package com.pay.billing.domain.model;
+package com.pay.billing.domain.dto;
 
 import org.springframework.security.core.GrantedAuthority;
 
 // 액세스 권한을 부여, 제어하는 ​​권한을 얻는다.
-public enum Role implements GrantedAuthority {
+public enum RoleDTO implements GrantedAuthority {
     ROLE_ADMIN, ROLE_CLIENT;
 
     public String getAuthority() {

--- a/src/main/java/com/pay/billing/domain/dto/UserDTO.java
+++ b/src/main/java/com/pay/billing/domain/dto/UserDTO.java
@@ -1,6 +1,5 @@
 package com.pay.billing.domain.dto;
 
-import com.pay.billing.domain.model.Role;
 import io.swagger.annotations.ApiModelProperty;
 
 import java.util.List;
@@ -14,7 +13,7 @@ public class UserDTO {
     @ApiModelProperty(position = 2)
     private String password;
     @ApiModelProperty(position = 3)
-    List<Role> roles;
+    List<RoleDTO> roleDTOS;
 
     public String getUsername() {
         return username;
@@ -40,12 +39,12 @@ public class UserDTO {
         this.password = password;
     }
 
-    public List<Role> getRoles() {
-        return roles;
+    public List<RoleDTO> getRoleDTOS() {
+        return roleDTOS;
     }
 
-    public void setRoles(List<Role> roles) {
-        this.roles = roles;
+    public void setRoleDTOS(List<RoleDTO> roleDTOS) {
+        this.roleDTOS = roleDTOS;
     }
 
 }

--- a/src/main/java/com/pay/billing/domain/dto/UserResponseDTO.java
+++ b/src/main/java/com/pay/billing/domain/dto/UserResponseDTO.java
@@ -13,7 +13,7 @@ public class UserResponseDTO {
     @ApiModelProperty(position = 2)
     private String email;
     @ApiModelProperty(position = 3)
-    List<RoleDTO> roleDTOList;
+    List<RoleDTO> roleDTOS;
 
     public Integer getId() {
         return id;
@@ -40,11 +40,11 @@ public class UserResponseDTO {
     }
 
     public List<RoleDTO> getRoleDTOS() {
-        return roleDTOList;
+        return roleDTOS;
     }
 
-    public void setRoleDTOS(List<RoleDTO> roleDTOList) {
-        this.roleDTOList = roleDTOList;
+    public void setRoleDTOS(List<RoleDTO> roleDTODTOList) {
+        this.roleDTOS = roleDTOS;
     }
 
 }

--- a/src/main/java/com/pay/billing/domain/dto/UserResponseDTO.java
+++ b/src/main/java/com/pay/billing/domain/dto/UserResponseDTO.java
@@ -1,6 +1,5 @@
 package com.pay.billing.domain.dto;
 
-import com.pay.billing.domain.model.Role;
 import io.swagger.annotations.ApiModelProperty;
 
 import java.util.List;
@@ -14,7 +13,7 @@ public class UserResponseDTO {
     @ApiModelProperty(position = 2)
     private String email;
     @ApiModelProperty(position = 3)
-    List<Role> roles;
+    List<RoleDTO> roleDTOList;
 
     public Integer getId() {
         return id;
@@ -40,12 +39,12 @@ public class UserResponseDTO {
         this.email = email;
     }
 
-    public List<Role> getRoles() {
-        return roles;
+    public List<RoleDTO> getRoleDTOS() {
+        return roleDTOList;
     }
 
-    public void setRoles(List<Role> roles) {
-        this.roles = roles;
+    public void setRoleDTOS(List<RoleDTO> roleDTOList) {
+        this.roleDTOList = roleDTOList;
     }
 
 }

--- a/src/main/java/com/pay/billing/domain/model/DataTransfer.java
+++ b/src/main/java/com/pay/billing/domain/model/DataTransfer.java
@@ -1,0 +1,24 @@
+package com.pay.billing.domain.model;
+
+import com.pay.billing.domain.model.common.CommonEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class DataTransfer extends CommonEntity {
+	@Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+	
+	@Column(length=450, nullable=false)
+	private String transferData;
+	
+	@Column(length=1, nullable=false)
+	private String successYn;
+}

--- a/src/main/java/com/pay/billing/domain/model/Payment.java
+++ b/src/main/java/com/pay/billing/domain/model/Payment.java
@@ -1,0 +1,55 @@
+package com.pay.billing.domain.model;
+
+import com.pay.billing.domain.model.common.CommonEntity;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@Entity
+@DynamicInsert
+@DynamicUpdate
+// 클래스에 존재하는 모든 필드에 대한 생성자를 자동으로 생성
+@AllArgsConstructor
+// 파라미터가 없는 생성자를 생성
+@NoArgsConstructor
+@Builder
+public class Payment extends CommonEntity {
+
+	@Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+	
+	@Column(length=20, nullable=false)
+	private String crdtCardNum;
+	
+	@Column(length=4, nullable=false)
+	private String validYm;
+	
+	@Column(length=3, nullable=false)
+	private String cvc;
+	
+	@Column(nullable=false)
+	private String encryptedCardInfo;
+	
+	@Column(length=2, nullable=false)
+	private Long installment;
+	
+	@Column(length=10, nullable=false)
+	private Long payAmount;
+
+	@Column(length=10)
+	private Long cancelAmount;
+	
+	@Column(length=10, nullable=false)
+	private Long payVat;
+	
+	@Column(length=10)
+	private Long cancelVat;
+	
+	@Column
+	private String note;
+}

--- a/src/main/java/com/pay/billing/domain/model/PaymentCancel.java
+++ b/src/main/java/com/pay/billing/domain/model/PaymentCancel.java
@@ -1,0 +1,27 @@
+package com.pay.billing.domain.model;
+
+import com.pay.billing.domain.model.common.CommonEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PaymentCancel extends CommonEntity {
+	@Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+	
+	@Column(nullable = false)
+	private Long paymentId;
+	
+	@Column(length=10, nullable=false)
+	private Long cancelAmount;
+	
+	@Column(length=10, nullable=false)
+	private Long vat;
+}

--- a/src/main/java/com/pay/billing/domain/model/User.java
+++ b/src/main/java/com/pay/billing/domain/model/User.java
@@ -1,5 +1,7 @@
 package com.pay.billing.domain.model;
 
+import com.pay.billing.domain.dto.RoleDTO;
+
 import javax.persistence.*;
 import javax.validation.constraints.Size;
 import java.util.List;
@@ -44,7 +46,7 @@ public class User {
     @ElementCollection의 관계 Key는 부모의 PK나 혹은 PK에 준하는 각 부모별로 동일한 값이 나올 수 없는 것으로 지정해야 한다.
     */
     @ElementCollection(fetch = FetchType.EAGER)
-    List<Role> roles;
+    List<RoleDTO> roles;
 
     public Integer getId() {
         return id;
@@ -78,11 +80,11 @@ public class User {
         this.password = password;
     }
 
-    public List<Role> getRoles() {
+    public List<RoleDTO> getRoles() {
         return roles;
     }
 
-    public void setRoles(List<Role> roles) {
+    public void setRoles(List<RoleDTO> roleDTOS) {
         this.roles = roles;
     }
 

--- a/src/main/java/com/pay/billing/domain/model/User.java
+++ b/src/main/java/com/pay/billing/domain/model/User.java
@@ -46,7 +46,7 @@ public class User {
     @ElementCollection의 관계 Key는 부모의 PK나 혹은 PK에 준하는 각 부모별로 동일한 값이 나올 수 없는 것으로 지정해야 한다.
     */
     @ElementCollection(fetch = FetchType.EAGER)
-    List<RoleDTO> roles;
+    List<RoleDTO> roleDTOS;
 
     public Integer getId() {
         return id;
@@ -80,12 +80,12 @@ public class User {
         this.password = password;
     }
 
-    public List<RoleDTO> getRoles() {
-        return roles;
+    public List<RoleDTO> getRoleDTOS() {
+        return roleDTOS;
     }
 
-    public void setRoles(List<RoleDTO> roleDTOS) {
-        this.roles = roles;
+    public void setRoleDTOS(List<RoleDTO> roleDTOS) {
+        this.roleDTOS = roleDTOS;
     }
 
 }

--- a/src/main/java/com/pay/billing/domain/model/common/CommonEntity.java
+++ b/src/main/java/com/pay/billing/domain/model/common/CommonEntity.java
@@ -1,0 +1,28 @@
+package com.pay.billing.domain.model.common;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+// 객체의 입장에서 공통 매핑 정보가 필요할 때 사용 (id, name ...)
+@MappedSuperclass
+// 엔티티를 DB에 적용하기 이전 이후에 커스텀 콜백을 요청할 수 있는 어노테이션 입니다.
+@EntityListeners(AuditingEntityListener.class)
+public abstract class CommonEntity {
+	
+	@Column(nullable = false, updatable = false)
+	@CreatedDate
+	private LocalDateTime insertDateTime;
+	
+	@Column(nullable = false)
+	@LastModifiedDate
+	private LocalDateTime modifyDateTime;
+	
+}

--- a/src/main/java/com/pay/billing/domain/repository/DataTransferRepository.java
+++ b/src/main/java/com/pay/billing/domain/repository/DataTransferRepository.java
@@ -1,0 +1,8 @@
+package com.pay.billing.domain.repository;
+
+import com.pay.billing.domain.model.DataTransfer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DataTransferRepository extends JpaRepository<DataTransfer, Long> {
+
+}

--- a/src/main/java/com/pay/billing/domain/repository/PaymentCancelRepository.java
+++ b/src/main/java/com/pay/billing/domain/repository/PaymentCancelRepository.java
@@ -1,0 +1,10 @@
+package com.pay.billing.domain.repository;
+
+import com.pay.billing.domain.model.PaymentCancel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaymentCancelRepository extends JpaRepository<PaymentCancel, Long> {
+
+}

--- a/src/main/java/com/pay/billing/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/pay/billing/domain/repository/PaymentRepository.java
@@ -1,0 +1,8 @@
+package com.pay.billing.domain.repository;
+
+import com.pay.billing.domain.model.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+}

--- a/src/main/java/com/pay/billing/service/PaymentService.java
+++ b/src/main/java/com/pay/billing/service/PaymentService.java
@@ -1,14 +1,26 @@
 package com.pay.billing.service;
 
 import com.pay.billing.domain.dto.PaymentDTO;
+import com.pay.billing.domain.repository.*;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Service
 public class PaymentService {
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private PaymentCancelRepository pamentCancelRepository;
+
+    @Autowired
+    private DataTransferRepository dataTransferRepository;
 
     /**
      * 신규거래 등록

--- a/src/main/java/com/pay/billing/service/PaymentService.java
+++ b/src/main/java/com/pay/billing/service/PaymentService.java
@@ -1,0 +1,53 @@
+package com.pay.billing.service;
+
+import com.pay.billing.domain.dto.PaymentDTO;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class PaymentService {
+
+    /**
+     * 신규거래 등록
+     *
+     * @param paymentDTO
+     */
+    @Transactional
+    public Map<String, Object> postPaymentData(PaymentDTO paymentDTO) throws Exception {
+        Map<String, Object> outputMap = new HashMap<String, Object>();
+
+        return outputMap;
+    }
+
+    /**
+     * 거래 조회
+     *
+     * @param paymentDTO
+     */
+    public Map<String, Object> getPaymentData(PaymentDTO paymentDTO) {
+        Map<String, Object> outputMap = new HashMap<String, Object>();
+        Map<String, Object> cardInfo = new HashMap<String, Object>();
+        Map<String, Object> amountInfo = new HashMap<String, Object>();
+        Long cancelAmt;
+
+        Long id = paymentDTO.getId();
+        //Optional<Payment> payment = paymentRepository.findById(id);
+
+        return outputMap;
+    }
+
+    /**
+     * 결제 취소(전체/부분)
+     *
+     * @param paymentDTO
+     */
+    public Map<String, Object> putPaymentData(PaymentDTO paymentDTO) {
+        Map<String, Object> outputMap = new HashMap<String, Object>();
+
+
+        return outputMap;
+    }
+}

--- a/src/main/java/com/pay/billing/service/PaymentService.java
+++ b/src/main/java/com/pay/billing/service/PaymentService.java
@@ -1,11 +1,12 @@
 package com.pay.billing.service;
 
 import com.pay.billing.domain.dto.PaymentDTO;
-import com.pay.billing.domain.repository.*;
+import com.pay.billing.domain.repository.DataTransferRepository;
+import com.pay.billing.domain.repository.PaymentCancelRepository;
+import com.pay.billing.domain.repository.PaymentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/pay/billing/service/UserService.java
+++ b/src/main/java/com/pay/billing/service/UserService.java
@@ -33,7 +33,7 @@ public class UserService {
     public String signin(String username, String password) {
         try {
             authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(username, password));
-            return jwtTokenProvider.createToken(username, userRepository.findByUsername(username).getRoles());
+            return jwtTokenProvider.createToken(username, userRepository.findByUsername(username).getRoleDTOS());
         } catch (AuthenticationException e) {
             throw new UserLoginException("Invalid username/password supplied");
         }
@@ -43,7 +43,7 @@ public class UserService {
         if (!userRepository.existsByUsername(user.getUsername())) {
             user.setPassword(passwordEncoder.encode(user.getPassword()));
             userRepository.save(user);
-            return jwtTokenProvider.createToken(user.getUsername(), user.getRoles());
+            return jwtTokenProvider.createToken(user.getUsername(), user.getRoleDTOS());
         } else {
             throw new UserInsertException("Username is already in use");
         }
@@ -66,7 +66,7 @@ public class UserService {
     }
 
     public String refresh(String username) {
-        return jwtTokenProvider.createToken(username, userRepository.findByUsername(username).getRoles());
+        return jwtTokenProvider.createToken(username, userRepository.findByUsername(username).getRoleDTOS());
     }
 
 }


### PR DESCRIPTION
```
1. 결제 API
- 카드정보과 금액정보를 입력받아서 카드사와 협의된 string 데이터로 DB에 저장합니다

2.  결제취소 API
- 결제에 대한 전체취소는 1번만 가능합니다.
- 부가가치세 정보를 넘기지 않는 경우, 결제데이터의 부가가치세 금액으로 취소합니다.
- 할부개월수 데이터는 00(일시불)로 저장합니다

3. 데이터 조회 API
- DB에 저장된 데이터를 조회해서 응답값으로 만들어줍니다.
- request : 관리번호(unique id)

4. API 요청 실패시 적절한 에러코드 응답
```